### PR TITLE
Add more support for zipfile management

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,7 +40,6 @@ steps:
         - push
       branch:
         - master
-        - feature/cleanup-zip
   - name: slack
     image: plugins/slack
     settings:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
         from_secret: pypi_password
     commands:
       - python setup.py sdist bdist_wheel
-      - 'twine upload --repository-url https://test.pypi.org/legacy/ dist/* -p "${PYPI_PASSWORD}" -u "${PYPI_USERNAME}"'
+      - twine upload --repository-url https://test.pypi.org/legacy/ dist/* -p $PYPI_PASSWORD -u $PYPI_USERNAME
     when:
       status:
         - success
@@ -32,7 +32,7 @@ steps:
         from_secret: pypi_password
     commands:
       - python setup.py sdist bdist_wheel
-      - 'twine upload dist/* -p "${PYPI_PASSWORD}" -u "${PYPI_USERNAME}"'
+      - twine upload dist/* -p $PYPI_PASSWORD -u $PYPI_USERNAME
     when:
       status:
         - success

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,17 +5,16 @@ name: skafossdk
 
 steps:
   - name: publish_stable
-    image: plugins/pypi
-    settings:
-      version: "${DRONE_TAG}"
-      username:
+    image: skafos/python-test:latest
+    environment:
+      VERSION: "${DRONE_TAG}"
+      PYPI_USERNAME:
         from_secret: pypi_username
-      password:
+      PYPI_PASSWORD:
         from_secret: pypi_password
-      distribution:
-        - sdist
-        - bdist_wheel
-      skip_build: false
+    commands:
+      - python setup.py sdist bdist_wheel
+      - 'twine upload --repository-url https://test.pypi.org/legacy/ dist/* -p "${PYPI_PASSWORD}" -u "${PYPI_USERNAME}"'
     when:
       status:
         - success
@@ -24,18 +23,16 @@ steps:
       ref:
         - refs/tags/*
   - name: publish_dev
-    image: plugins/pypi
-    settings:
-      build_number: "${DRONE_BUILD_NUMBER}"
-      repository: "https://test.pypi.org/legacy/"
-      username:
+    image: skafos/python-test:latest
+    environment:
+      BUILD_NUMBER: "${DRONE_BUILD_NUMBER}"
+      PYPI_USERNAME:
         from_secret: pypi_username
-      password:
+      PYPI_PASSWORD:
         from_secret: pypi_password
-      distribution:
-        - sdist
-        - bdist_wheel
-      skip_build: false
+    commands:
+      - python setup.py sdist bdist_wheel
+      - 'twine upload dist/* -p "${PYPI_PASSWORD}" -u "${PYPI_USERNAME}"'
     when:
       status:
         - success
@@ -43,6 +40,7 @@ steps:
         - push
       branch:
         - master
+        - feature/cleanup-zip
   - name: slack
     image: plugins/slack
     settings:

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ def read(fname):
 with open('requirements.txt', 'r') as r:
     REQS = r.read().splitlines()
 
-if "PLUGIN_VERSION" in os.environ:
-    VERSION = os.environ["PLUGIN_VERSION"]
+if "VERSION" in os.environ:
+    VERSION = os.environ["VERSION"]
 else:
-    if "PLUGIN_BUILD_NUMBER" in os.environ:
-        VERSION = read("skafos/VERSION") + ".dev" + os.environ["PLUGIN_BUILD_NUMBER"]
+    if "BUILD_NUMBER" in os.environ:
+        VERSION = read("skafos/VERSION") + ".dev" + os.environ["BUILD_NUMBER"]
     else:
         VERSION = read("skafos/VERSION")
 

--- a/skafos/models.py
+++ b/skafos/models.py
@@ -134,7 +134,7 @@ def upload_version(files, description=None, verbose=True, **kwargs) -> dict:
 
     :raises:
         * `InvalidTokenError` - if improper API token is used or is missing entirely.
-        * `InvalidParamError` - if improper connection params are passed or a zip file exists in your working directory with the same name that Skafos tries to create before upload.
+        * `InvalidParamError` - if improper connection params are passed or missing entirely.
         * `UploadFailedError` - if there's a local network or API related issue.
 
     """

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -9,8 +9,7 @@ import pytest
 import skafos
 from skafos.exceptions import *
 from skafos.http import _generate_required_params
-from skafos.models import upload_version, _create_filelist
-from skafos.models import _make_model_filename, _check_description
+from skafos.models import upload_version, _create_filename, _check_description
 from constants import *
 
 
@@ -41,20 +40,15 @@ class TestUnit(object):
             # Missing model name here should raise an exception
             res = _generate_required_params(PARAMS)
 
-    # Test making a filelist
-    def test_filelist_create(self):
-        test_filelist = _create_filelist(TESTING_FAKE_FILE)
-        assert isinstance(test_filelist, list)
-
     # Test creating a filename
     def test_filename_creation(self):
-        test_model_filename = _make_model_filename(TESTING_FAKE_FILE)
+        test_model_filename = _create_filename(TESTING_FAKE_FILE)
         assert test_model_filename == TESTING_FAKE_FILE + ".zip"
 
     # Test creating a filename that's already got a zip extension
     def test_filename_creation_zip(self):
         testing_fake_file_zip = TESTING_FAKE_FILE + ".zip"
-        test_model_filename = _make_model_filename(testing_fake_file_zip)
+        test_model_filename = _create_filename(testing_fake_file_zip)
         assert test_model_filename == testing_fake_file_zip
 
     # Test an invalid description to make sure error is thrown


### PR DESCRIPTION
- On upload, if user passes in a single zip file with the naming convention `<model-name>.zip`, we just upload that file and leave it alone.
- Otherwise, we now create a tmp directory to place the new artifact, upload, then cleanup.